### PR TITLE
[Feature]: Implement /access/history Endpoint

### DIFF
--- a/src/controllers/access.controller.ts
+++ b/src/controllers/access.controller.ts
@@ -2,9 +2,9 @@ import { Request, Response } from "express";
 import { AccessService } from "../services/access.service";
 
 export class AccessController {
-  private readonly accessTokenservice;
-  constructor(accessTokenservice?: AccessService) {
-    this.accessTokenservice = accessTokenservice ?? new AccessService();
+  private readonly accessService;
+  constructor(accessService?: AccessService) {
+    this.accessService = accessService ?? new AccessService();
   }
   public issueAccessToken = async (req: Request, res: Response) => {
     const refreshToken = req.cookies.refresh_token;
@@ -14,7 +14,7 @@ export class AccessController {
       }
 
       const { ip, user_agent } = (req as any).clientInfo;
-      const result: any = await this.accessTokenservice.generateFromRefresh(
+      const result: any = await this.accessService.generateFromRefresh(
         refreshToken,
         ip,
         user_agent
@@ -30,13 +30,22 @@ export class AccessController {
   };
   public getUserInfo = async (req: Request, res: Response) => {
     try {
-      const result: any = await this.accessTokenservice.getUser(
-        (req as any).userId
-      );
+      const result: any = await this.accessService.getUser((req as any).userId);
       if ("error" in result) {
         res.status(result.status).json({ message: result.error });
         return;
       }
+      res.status(200).json(result);
+    } catch (error) {
+      res.status(500).json("Internal server error");
+    }
+  };
+
+  public acesssHistory = async (req: Request, res: Response) => {
+    try {
+      const result: any = await this.accessService.getHistory(
+        (req as any).userId
+      );
       res.status(200).json(result);
     } catch (error) {
       res.status(500).json("Internal server error");

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -12,14 +12,14 @@ export const verifyAccessToken = async (
   const ip = getClientIp(req);
   const user_agent = req.headers["user-agent"];
 
+  if (!token) {
+    return res.status(401).json({ message: "Access token missing" });
+  }
+
   if (!ip || !user_agent) {
     return res.status(401).json({
       error: "Missing IP address or User-Agent in request",
     });
-  }
-
-  if (!token) {
-    return res.status(401).json({ message: "Access token missing" });
   }
 
   const tokenUtil = new TokenUtil();

--- a/src/repositories/sessions.repository.ts
+++ b/src/repositories/sessions.repository.ts
@@ -19,6 +19,14 @@ export class SessionsRepository {
     );
   };
 
+  public getAllSessionbyId = async (user_id: string) => {
+    const result = await this.database.query(
+      `SELECT ip,user_agent,created_at AS login_time,expires_at  FROM sessions WHERE user_id = $1 `,
+      [user_id]
+    );
+    return result.rows || null;
+  };
+
   public getSession = async (
     user_id: string,
     ip: string,

--- a/src/routes/access.routes.ts
+++ b/src/routes/access.routes.ts
@@ -4,14 +4,14 @@ import { requestMeta } from "../middlewares/requestMeta";
 import { AccessController } from "../controllers/access.controller";
 import { verifyAccessToken } from "../middlewares/auth.middleware";
 
-const accessTokencontroller = new AccessController();
+const accessController = new AccessController();
 const acesssRouter = Router();
 
 acesssRouter.get(
   "/token/refresh",
   requestMeta,
-  accessTokencontroller.issueAccessToken
+  accessController.issueAccessToken
 );
-acesssRouter.get("/me", verifyAccessToken, accessTokencontroller.getUserInfo);
-
+acesssRouter.get("/me", verifyAccessToken, accessController.getUserInfo);
+acesssRouter.get("/history", verifyAccessToken, accessController.acesssHistory);
 export default acesssRouter;

--- a/src/services/access.service.ts
+++ b/src/services/access.service.ts
@@ -70,5 +70,8 @@ export class AccessService {
     };
   };
 
-  getHistory = async (id: string) => {};
+  getHistory = async (id: string) => {
+    const result = await this.SessionRepo.getAllSessionbyId(id);
+    return result;
+  };
 }


### PR DESCRIPTION

Closes #23

📌 Description
Added a new endpoint GET /access/history in access_core to let users view their recent login activity with metadata (IP, user agent, issuedAt, expiresAt).

✅ Changes
New route: /access/history

Auth check for user

Query sessions from DB

Return access history (IP, UA, issuedAt, expiresAt)

Added unit + integration tests

